### PR TITLE
Set cos_critical_rad correctly

### DIFF
--- a/apriltag/Cargo.toml
+++ b/apriltag/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 license = "BSD-2-Clause"
 
 [dependencies]
+approx = { version = "0.5.1" }
 apriltag-sys = { version = "0.3.0", path = "../apriltag-sys" }
 libc = "0.2.139"
-measurements = "0.11.0"
 noisy_float = "0.2.0"
 thiserror = "1.0.38"
 

--- a/apriltag/src/error.rs
+++ b/apriltag/src/error.rs
@@ -11,4 +11,7 @@ pub enum Error {
 
     #[error("Unable to create a detector: {reason}")]
     CreateDetectorError { reason: String },
+
+    #[error("Invalid critical angle for detector: {val} degrees")]
+    CriticalAngleError { val: f32 },
 }


### PR DESCRIPTION
In QuadThresholds, the parameter min_opposite_angle was being used to directly set cos_critical_rad, but that's just a cached version of cos(critical_rad), not an entierly different parameter.

This sets it to the proper value.